### PR TITLE
proc: Remove verifiedbootstate flag from /proc/cmdline

### DIFF
--- a/fs/proc/cmdline.c
+++ b/fs/proc/cmdline.c
@@ -3,13 +3,15 @@
 #include <linux/proc_fs.h>
 #include <linux/seq_file.h>
 #include <htc_debug/stability/dirty_file_detector.h>
+#include <asm/setup.h>
 
+static char new_command_line[COMMAND_LINE_SIZE];
 static int cmdline_proc_show(struct seq_file *m, void *v)
 {
 #ifdef CONFIG_DIRTY_SYSTEM_DETECTOR
 	seq_printf(m, "%s system_dirty=%d\n", saved_command_line, is_system_dirty());
 #else
-	seq_printf(m, "%s\n", saved_command_line);
+	seq_printf(m, "%s\n", new_command_line);
 #endif
 	return 0;
 }
@@ -27,7 +29,30 @@ static const struct file_operations cmdline_proc_fops = {
 };
 
 static int __init proc_cmdline_init(void)
-{
+ {
+ 	char *offset_addr, *cmd = new_command_line;
+ 
+ 	strcpy(cmd, saved_command_line);
+ 
+ 	/*
+ 	 * Remove 'androidboot.verifiedbootstate' flag from command line seen
+ 	 * by userspace in order to pass SafetyNet CTS check.
+ 	 */
+ 	offset_addr = strstr(cmd, "androidboot.verifiedbootstate=");
+ 	if (offset_addr) {
+ 		size_t i, len, offset;
+ 
+ 		len = strlen(cmd);
+ 		offset = offset_addr - cmd;
+ 
+ 		for (i = 1; i < (len - offset); i++) {
+ 			if (cmd[offset + i] == ' ')
+ 				break;
+ 		}
+ 
+ 		memmove(offset_addr, &cmd[offset + i + 1], len - i - offset);
+ 	}
+	 
 	proc_create("cmdline", 0, NULL, &cmdline_proc_fops);
 	return 0;
 }


### PR DESCRIPTION
I think this should work. I've got no programming knowledge and just copy pasted this from SultanXDA's OP3 CM kernel :P 

"Userspace parses this and sets the ro.boot.verifiedbootstate prop
according to the value that this flag has. When ro.boot.verifiedbootstate
is not 'green', SafetyNet is tripped and fails the CTS test.

Hide verifiedbootstate from /proc/cmdline in order to fix the failed
SafetyNet CTS check."
